### PR TITLE
Prevents get-poetry.py from modifying $PATH

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -2,4 +2,4 @@
 
 set -e
 
-curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | POETRY_HOME=$ASDF_INSTALL_PATH python - --version $ASDF_INSTALL_VERSION
+curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | POETRY_HOME=$ASDF_INSTALL_PATH python - --version $ASDF_INSTALL_VERSION --no-modify-path


### PR DESCRIPTION
This is not necessary when using asdf since asdf manages the PATH. This
will prevent dotfiles from getting annoyingly modified when installing
new versions of poetry.

See:
https://github.com/python-poetry/poetry/blob/master/get-poetry.py#L1024